### PR TITLE
Define relay monorepo group in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,10 @@
       "matchDepTypes": ["devDependencies"],
       "rangeStrategy": "pin",
       "labels": ["devDependencies"]
+    },
+    {
+      "matchSourceUrlPrefixes": ["https://github.com/facebook/relay"],
+      "groupName": "Relay monorepo packages"
     }
   ]
 }


### PR DESCRIPTION
## Why
to unify #80 and #79 