### PR TITLE
Remove `devDependencies` from docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,9 @@ ENV NODE_ENV production
 ARG GIT_SHA
 RUN --mount=type=secret,id=dotenv,dst=/app/.env yarn build && rm -rf .next/static/**/*.map
 
+RUN --mount=type=cache,target=/usr/local/share/.cache/yarn,id=yarn-cache,sharing=shared \
+  yarn install --frozen-lockfile --no-progress --production
+
 #  App
 #-----------------------------------------------
 ENTRYPOINT ["/usr/bin/tini", "--"]


### PR DESCRIPTION
## Why
Make docker images lightweight to speed up CI build jobs.